### PR TITLE
Add Minsk (Belarus).

### DIFF
--- a/etc/cities.csv
+++ b/etc/cities.csv
@@ -150,6 +150,7 @@ Melbourne::en::AT:other:144.68 -38.02 145.30 -37.53:3600000::
 Memphis::en::US:other:-90.361 34.91 -89.653 35.324:1300000::
 MexicoCity:en!Mexico City,de!Mexiko-Stadt,es!Ciudad de Méxicoeses::es:MX:other:-99.2708 19.3095 -98.9714 19.5329:21000000::
 Miami::en:es:US:other:-80.3244 25.6548 -80.0473 25.8567:832273::
+Minsk:en!Minsk,de!Minsk,ru!Минск!be!Мінск::ru:RU:eu:27.374018 53.793846 28.0609 53.97179:1982444::
 Moenchengladbach:de!Mönchengladbach,en!Mönchengladbach::de:DE::5.75 50.99 6.65 51.48:380000::Venlo
 Montevideo:::es:PY:other:-56.49 -34.950 -55.60 -34.50:1700000::
 Montpellier:::fr:FR:eu:3.643 43.377 4.16 43.763:265634::

--- a/etc/cities.txt
+++ b/etc/cities.txt
@@ -233,3 +233,4 @@ LaPaz
 Sucre
 Cusco
 LaPlata
+Minsk


### PR DESCRIPTION
I am not sure about the correctness of some columns.

In Belarus most of peoples speak in Russian. But there is two official languages: Russian and Belarusian. I set the value for `local language` column to "ru".

Also I not sure about column `coord`. I set the values given from https://osmnames.org/ for Minsk (city) from `boundingbox` field.

For column `population` I got value from https://www.openstreetmap.org/relation/59195.


